### PR TITLE
Puppet6 system model

### DIFF
--- a/manifests/filter/system_model.pp
+++ b/manifests/filter/system_model.pp
@@ -126,35 +126,37 @@
 # * Greg Swift <mailto:greg.swift@rackspace.com>
 # * c/o Cloud Integration Ops <mailto:cit-ops@rackspace.com>
 #
-define repose::filter::system_model (
-  $ensure              = present,
-  $filename            = 'system-model.cfg.xml',
-  $app_name            = 'repose',
-  $nodes               = undef,
-  $filters             = undef,
-  $services            = undef,
-  $endpoints           = undef,
-  $port                = $repose::port,
-  $https_port          = undef,
-  $repose9             = false,
-  $rewrite_host_header = undef,
-  $service_cluster     = undef,
-  $tracing_header      = {},
-  $encoded_headers     = [],
+class repose::filter::system_model (
+  Variant[Enum['absent','present', 'latest'],Pattern[/\d*\.\d*\.\d*\.\d*/]] $ensure,
+  String $filename            = 'system-model.cfg.xml',
+  String $app_name            = 'repose',
+  Optional[String] $nodes,
+  Optional[String] $filters,
+  Optional[String] $services,
+  Optional[String] $endpoints,
+  Integer $port               = $repose::port,
+  String $https_port,
+  String $rewrite_host_header,
+  $service_cluster,
+  $tracing_header            = {},
+  Array $encoded_headers     = [],
 ) {
 
 ### Validate parameters
 
 ## ensure
-  if ! ($ensure in [ present, absent ]) {
-    fail("\"${ensure}\" is not a valid ensure parameter value")
+  if ! ($ensure) {
+    fail("\"${ensure}\" is required. It should be present, absent, latest or a version")
   } else {
     $file_ensure = $ensure ? {
-      present => file,
       absent  => absent,
+      default => file,
     }
   }
   if $::debug {
+    if $ensure != $repose::ensure {
+      debug('$ensure overridden by class parameter')
+    }
     debug("\$ensure = '${ensure}'")
   }
 

--- a/manifests/filter/system_model.pp
+++ b/manifests/filter/system_model.pp
@@ -134,7 +134,7 @@ class repose::filter::system_model (
   Optional[String] $filters,
   Optional[String] $services,
   Optional[String] $endpoints,
-  Integer $port               = $repose::port,
+  String $port                = $repose::port,
   String $https_port,
   String $rewrite_host_header,
   $service_cluster,

--- a/manifests/filter/system_model.pp
+++ b/manifests/filter/system_model.pp
@@ -126,20 +126,20 @@
 # * Greg Swift <mailto:greg.swift@rackspace.com>
 # * c/o Cloud Integration Ops <mailto:cit-ops@rackspace.com>
 #
-class repose::filter::system_model (
-  Variant[Enum['absent','present', 'latest'],Pattern[/\d*\.\d*\.\d*\.\d*/]] $ensure,
-  String $filename            = 'system-model.cfg.xml',
-  String $app_name            = 'repose',
-  Optional[String] $nodes,
-  Optional[String] $filters,
-  Optional[String] $services,
-  Optional[String] $endpoints,
-  String $port                = $repose::port,
-  String $https_port,
-  String $rewrite_host_header,
-  $service_cluster,
-  $tracing_header            = {},
-  Array $encoded_headers     = [],
+define repose::filter::system_model (
+  Variant[Enum['absent','present', 'latest'],Pattern[/\d*\.\d*\.\d*\.\d*/]] $ensure = $repose::ensure,
+  String $filename                                          = 'system-model.cfg.xml',
+  String $app_name                                          = 'repose',
+  Optional[Hash[Integer, Hash[String, String]]] $filters    = undef,
+  Optional[Hash[Integer, String]] $services                 = undef,
+  Optional[Array] $nodes                                    = undef,
+  Optional[Array] $endpoints                                = undef,
+  String $port                                              = $repose::port,
+  Optional[String] $https_port                              = undef,
+  Optional[String] $rewrite_host_header                     = undef,
+  Optional[String] $service_cluster                         = undef,
+  NotUndef $tracing_header                                  = {},
+  Array $encoded_headers                                    = [],
 ) {
 
 ### Validate parameters

--- a/spec/defines/filter/system_model_spec.rb
+++ b/spec/defines/filter/system_model_spec.rb
@@ -5,12 +5,15 @@ describe 'repose::filter::system_model', :type => :define do
   end
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:facts) { os_facts }
+      let(:facts) do
+        os_facts
+      end
+
 
       context 'default parameters' do
         let(:title) { 'default' }
         it {
-          is_expected.to compile.and_raise_error(Puppet::Error, /nodes is a required/)
+          should raise_error(/nodes is a required/)
         }
       end
 
@@ -20,7 +23,7 @@ describe 'repose::filter::system_model', :type => :define do
           :app_name => 'repose'
         } }
         it {
-          is_expected.to compile.and_raise_error(Puppet::Error, /nodes is a required/)
+          should raise_error(/nodes is a required/)
         }
       end
 
@@ -31,7 +34,7 @@ describe 'repose::filter::system_model', :type => :define do
           :nodes    => ['app1', 'app2' ],
         } }
         it {
-          is_expected.to compile.and_raise_error(Puppet::Error, /filters is a required/)
+          should raise_error(/filters is a required/)
         }
       end
 
@@ -54,7 +57,7 @@ describe 'repose::filter::system_model', :type => :define do
           }
         } }
         it {
-          is_expected.to compile.and_raise_error(Puppet::Error, /endpoints is a required/)
+          should raise_error(/endpoints is a required/)
         }
       end
 
@@ -89,25 +92,24 @@ describe 'repose::filter::system_model', :type => :define do
           ]
         } }
         it {
-          is_expected.to contain_file('/etc/repose/system-model.cfg.xml').with(
+          should contain_file('/etc/repose/system-model.cfg.xml').with(
             'ensure' => 'file',
             'owner'  => 'repose',
             'group'  => 'repose',
             'mode'   => '0660').
-            with_content(/id=\"repose\"/).
-            with_content(/id=\"repose_app1\"/).
-            with_content(/hostname=\"app1\"/).
-            with_content(/http-port=\"8080\"/).
+            with_content(/id="repose_app1"/).
+            with_content(/hostname="app1"/).
+            with_content(/http-port="8080"/).
             without_content(/https-port=/).
-            with_content(/name=\"content-normalization\"/).
-            with_content(/configuration=\"pre-ratelimit-httplog\.cfg\.xml\" name=\"http-logging\"/).
-            with_content(/name=\"ip-identity\"/).
-            with_content(/name=\"client-auth\"/).
-            with_content(/uri-regex=\"\.\*\"/).
-            with_content(/name=\"rate-limiting\"/).
-            with_content(/configuration=\"http-logging\.cfg\.xml\" name=\"http-logging\"/).
-            with_content(/name=\"compression\"/).
-            with_content(/endpoint default=\"true\" hostname=\"localhost\" id=\"localhost\" port=\"80\" protocol=\"http\" root-path=\"\"/)
+            with_content(/name="content-normalization"/).
+            with_content(/configuration="pre-ratelimit-httplog.cfg.xml" name="http-logging"/).
+            with_content(/name="ip-identity"/).
+            with_content(/name="client-auth"/).
+            with_content(/uri-regex=".*"/).
+            with_content(/name="rate-limiting"/).
+            with_content(/configuration="http-logging.cfg.xml" name="http-logging"/).
+            with_content(/name="compression"/).
+            with_content(/endpoint default="true" hostname="localhost" id="localhost" port="80" protocol="http" root-path=""/)
         }
       end
 
@@ -118,7 +120,6 @@ describe 'repose::filter::system_model', :type => :define do
           :filename   => 'system-model.cfg.xml',
           :app_name   => 'repose',
           :nodes      => ['app1', 'app2' ],
-          :port       => false,
           :https_port => '8443',
           :filters    => {
             10 => { 'name' => 'content-normalization' },
@@ -144,25 +145,23 @@ describe 'repose::filter::system_model', :type => :define do
           ]
         } }
         it {
-          is_expected.to contain_file('/etc/repose/system-model.cfg.xml').with(
+          should contain_file('/etc/repose/system-model.cfg.xml').with(
             'ensure' => 'file',
             'owner'  => 'repose',
             'group'  => 'repose',
             'mode'   => '0660').
-            with_content(/id=\"repose\"/).
-            with_content(/id=\"repose_app1\"/).
-            with_content(/hostname=\"app1\"/).
-            without_content(/http-port=/).
-            with_content(/https-port=\"8443\"/).
-            with_content(/name=\"content-normalization\"/).
-            with_content(/configuration=\"pre-ratelimit-httplog\.cfg\.xml\" name=\"http-logging\"/).
-            with_content(/name=\"ip-identity\"/).
-            with_content(/name=\"client-auth\"/).
-            with_content(/uri-regex=\"\.\*\"/).
-            with_content(/name=\"rate-limiting\"/).
-            with_content(/configuration=\"http-logging\.cfg\.xml\" name=\"http-logging\"/).
-            with_content(/name=\"compression\"/).
-            with_content(/endpoint default=\"true\" hostname=\"localhost\" id=\"localhost\" port=\"80\" protocol=\"http\" root-path=\"\"/)
+            with_content(/id="repose_app1"/).
+            with_content(/hostname="app1"/).
+            with_content(/https-port="8443"/).
+            with_content(/name="content-normalization"/).
+            with_content(/configuration="pre-ratelimit-httplog.cfg.xml" name="http-logging"/).
+            with_content(/name="ip-identity"/).
+            with_content(/name="client-auth"/).
+            with_content(/uri-regex=".*"/).
+            with_content(/name="rate-limiting"/).
+            with_content(/configuration="http-logging.cfg.xml" name="http-logging"/).
+            with_content(/name="compression"/).
+            with_content(/endpoint default="true" hostname="localhost" id="localhost" port="80" protocol="http" root-path=""/)
         }
       end
 
@@ -199,26 +198,25 @@ describe 'repose::filter::system_model', :type => :define do
           :tracing_header => { 'secondary-plain-text' => 'true' },
         } }
         it {
-          is_expected.to contain_file('/etc/repose/system-model.cfg.xml').with(
+          should contain_file('/etc/repose/system-model.cfg.xml').with(
             'ensure' => 'file',
             'owner'  => 'repose',
             'group'  => 'repose',
             'mode'   => '0660').
-            with_content(/id=\"repose\"/).
-            with_content(/id=\"repose_app1\"/).
-            with_content(/hostname=\"app1\"/).
-            with_content(/http-port=\"8080\"/).
-            with_content(/https-port=\"8443\"/).
-            with_content(/name=\"content-normalization\"/).
-            with_content(/configuration=\"pre-ratelimit-httplog\.cfg\.xml\" name=\"http-logging\"/).
-            with_content(/name=\"ip-identity\"/).
-            with_content(/name=\"client-auth\"/).
-            with_content(/uri-regex=\"\.\*\"/).
-            with_content(/name=\"rate-limiting\"/).
-            with_content(/configuration=\"http-logging\.cfg\.xml\" name=\"http-logging\"/).
-            with_content(/name=\"compression\"/).
-            with_content(/endpoint default=\"true\" hostname=\"localhost\" id=\"localhost\" port=\"80\" protocol=\"http\" root-path=\"\"/).
-            with_content(/tracing-header secondary-plain-text=\"true\"/)
+            with_content(/id="repose_app1"/).
+            with_content(/hostname="app1"/).
+            with_content(/http-port="8080"/).
+            with_content(/https-port="8443"/).
+            with_content(/name="content-normalization"/).
+            with_content(/configuration="pre-ratelimit-httplog.cfg.xml" name="http-logging"/).
+            with_content(/name="ip-identity"/).
+            with_content(/name="client-auth"/).
+            with_content(/uri-regex=".*"/).
+            with_content(/name="rate-limiting"/).
+            with_content(/configuration="http-logging.cfg.xml" name="http-logging"/).
+            with_content(/name="compression"/).
+            with_content(/endpoint default="true" hostname="localhost" id="localhost" port="80" protocol="http" root-path=""/).
+            with_content(/tracing-header secondary-plain-text="true"/)
         }
       end
 
@@ -244,76 +242,10 @@ describe 'repose::filter::system_model', :type => :define do
           ]
         } }
         it {
-          is_expected.to contain_file('/etc/repose/system-model.cfg.xml').
+          should contain_file('/etc/repose/system-model.cfg.xml').
             without_content(/tracing-header/).
             without_content(/rewrite-host-header/).
             without_content(/services/)
-        }
-      end
-
-      context 'defaults plus setting repose9 param' do
-        let(:title) { 'default' }
-        let(:params) { {
-          :ensure     => 'present',
-          :repose9    => 'true',
-          :filename   => 'system-model.cfg.xml',
-          :app_name   => 'repose',
-          :nodes      => ['app1', 'app2' ],
-          :filters    => {
-            10 => { 'name' => 'ip-identity' },
-          },
-          :endpoints  => [
-            {
-              'id'        => 'localhost',
-              'protocol'  => 'http',
-              'hostname'  => 'localhost',
-              'root-path' => '',
-              'port'      => '80',
-              'default'   => 'true'
-            },
-          ]
-        } }
-        it {
-          is_expected.to contain_file('/etc/repose/system-model.cfg.xml').
-            without_content(/tracing-header/).
-            without_content(/rewrite-host-header/).
-            without_content(/repose-cluster/).
-            without_content(/services/)
-        }
-      end
-
-      context 'defaults plus setting repose9 param with encoded headers' do
-
-        let(:title) { 'default' }
-        let(:params) { {
-            :ensure     => 'present',
-            :repose9    => 'true',
-            :filename   => 'system-model.cfg.xml',
-            :app_name   => 'repose',
-            :nodes      => ['app1', 'app2' ],
-            :filters    => {
-                10 => { 'name' => 'ip-identity' },
-            },
-            :endpoints  => [
-                {
-                    'id'        => 'localhost',
-                    'protocol'  => 'http',
-                    'hostname'  => 'localhost',
-                    'root-path' => '',
-                    'port'      => '80',
-                    'default'   => 'true'
-                },
-            ],
-            :encoded_headers    => ['x-user-name', 'x-rax-roles'],
-
-        } }
-        it {
-          is_expected.to contain_file('/etc/repose/system-model.cfg.xml').
-                    without_content(/tracing-header/).
-                    without_content(/rewrite-host-header/).
-                    without_content(/repose-cluster/).
-                    without_content(/services/).
-                    with_content(/url-encode-headers="x-user-name,x-rax-roles"/)
         }
       end
     end

--- a/spec/defines/filter/system_model_spec.rb
+++ b/spec/defines/filter/system_model_spec.rb
@@ -5,15 +5,12 @@ describe 'repose::filter::system_model', :type => :define do
   end
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:facts) do
-        os_facts
-      end
-
+      let(:facts) { os_facts }
 
       context 'default parameters' do
         let(:title) { 'default' }
         it {
-          should raise_error(Puppet::Error, /nodes is a required/)
+          is_expected.to compile.and_raise_error(Puppet::Error, /nodes is a required/)
         }
       end
 
@@ -23,7 +20,7 @@ describe 'repose::filter::system_model', :type => :define do
           :app_name => 'repose'
         } }
         it {
-          should raise_error(Puppet::Error, /nodes is a required/)
+          is_expected.to compile.and_raise_error(Puppet::Error, /nodes is a required/)
         }
       end
 
@@ -34,7 +31,7 @@ describe 'repose::filter::system_model', :type => :define do
           :nodes    => ['app1', 'app2' ],
         } }
         it {
-          should raise_error(Puppet::Error, /filters is a required/)
+          is_expected.to compile.and_raise_error(Puppet::Error, /filters is a required/)
         }
       end
 
@@ -57,7 +54,7 @@ describe 'repose::filter::system_model', :type => :define do
           }
         } }
         it {
-          should raise_error(Puppet::Error, /endpoints is a required/)
+          is_expected.to compile.and_raise_error(Puppet::Error, /endpoints is a required/)
         }
       end
 
@@ -92,7 +89,7 @@ describe 'repose::filter::system_model', :type => :define do
           ]
         } }
         it {
-          should contain_file('/etc/repose/system-model.cfg.xml').with(
+          is_expected.to contain_file('/etc/repose/system-model.cfg.xml').with(
             'ensure' => 'file',
             'owner'  => 'repose',
             'group'  => 'repose',
@@ -147,7 +144,7 @@ describe 'repose::filter::system_model', :type => :define do
           ]
         } }
         it {
-          should contain_file('/etc/repose/system-model.cfg.xml').with(
+          is_expected.to contain_file('/etc/repose/system-model.cfg.xml').with(
             'ensure' => 'file',
             'owner'  => 'repose',
             'group'  => 'repose',
@@ -202,7 +199,7 @@ describe 'repose::filter::system_model', :type => :define do
           :tracing_header => { 'secondary-plain-text' => 'true' },
         } }
         it {
-          should contain_file('/etc/repose/system-model.cfg.xml').with(
+          is_expected.to contain_file('/etc/repose/system-model.cfg.xml').with(
             'ensure' => 'file',
             'owner'  => 'repose',
             'group'  => 'repose',
@@ -247,7 +244,7 @@ describe 'repose::filter::system_model', :type => :define do
           ]
         } }
         it {
-          should contain_file('/etc/repose/system-model.cfg.xml').
+          is_expected.to contain_file('/etc/repose/system-model.cfg.xml').
             without_content(/tracing-header/).
             without_content(/rewrite-host-header/).
             without_content(/services/)
@@ -277,7 +274,7 @@ describe 'repose::filter::system_model', :type => :define do
           ]
         } }
         it {
-          should contain_file('/etc/repose/system-model.cfg.xml').
+          is_expected.to contain_file('/etc/repose/system-model.cfg.xml').
             without_content(/tracing-header/).
             without_content(/rewrite-host-header/).
             without_content(/repose-cluster/).
@@ -311,7 +308,7 @@ describe 'repose::filter::system_model', :type => :define do
 
         } }
         it {
-          should contain_file('/etc/repose/system-model.cfg.xml').
+          is_expected.to contain_file('/etc/repose/system-model.cfg.xml').
                     without_content(/tracing-header/).
                     without_content(/rewrite-host-header/).
                     without_content(/repose-cluster/).

--- a/templates/system-model.cfg.xml.erb
+++ b/templates/system-model.cfg.xml.erb
@@ -18,7 +18,7 @@
   <%- end -%>
     </services>
 <%- end -%>
-    <destinations <%- if @repose9 && ! @encoded_headers.empty?  -%> url-encode-headers="<%= @encoded_headers.join(",")%>" <%- end -%> >
+    <destinations <%- if ! @encoded_headers.empty?  -%> url-encode-headers="<%= @encoded_headers.join(",")%>" <%- end -%> >
 <%- @endpoints.each do |endpoint| -%>
       <endpoint <% endpoint.sort.map do |param, value| %><%= param %>="<%= value %>" <% end %>/>
 <%- end -%>

--- a/templates/system-model.cfg.xml.erb
+++ b/templates/system-model.cfg.xml.erb
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- To configure Repose see: http://wiki.openrepose.org/display/REPOSE/Configuration -->
-<%- if ! @repose9 %>
-<system-model xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/system-model/v2.0">
-  <%- if ! @rewrite_host_header.nil? %>
-  <repose-cluster id="<%= @app_name %>" rewrite-host-header="<%= @rewrite_host_header %>">
-  <% else %>
-  <repose-cluster id="<%= @app_name %>">
-  <% end %>
-  <% else %>
 <system-model xmlns="http://<%= scope.lookupvar('::repose::cfg_namespace_host') %>/repose/system-model/v2.0" <%- if ! @rewrite_host_header.nil? %>rewrite-host-header="<%= @rewrite_host_header -%>"<%- end -%>>
-<% end %>
     <nodes>
 <%- @nodes.sort.each do |node| -%>
         <node id="<%= @app_name %>_<%= node.split('.')[0] %>" hostname="<%= node %>"<%- if @port %> http-port="<%= @port -%>"<%- end -%><%- if @https_port %> https-port="<%= @https_port -%>"<%- end -%>/>
@@ -32,9 +23,6 @@
       <endpoint <% endpoint.sort.map do |param, value| %><%= param %>="<%= value %>" <% end %>/>
 <%- end -%>
     </destinations>
-<%- if ! @repose9 %>
-  </repose-cluster>
-<% end %>
 <%- if ! @service_cluster.nil? -%>
   <service-cluster id="<%= @service_cluster['name'] %>">
     <nodes>


### PR DESCRIPTION
# System Model Puppet 6 Update

Updated the System Model by request of @jstraw and @bjoshua.  

## Code Under Test

The change is primarily explicit typing of the parameters and some subsequent test changes as a consequence of those actions. A parameter called `repose9` was removed under the premise that this version change will be a hard transition to end support for earlier versions of the app which removes the need for the boolean. Finally, the pdk test bundle also had some syntax changes for the tests.

### pp updates

The system model was parameterized without removal of the existing defaults. The defaults consisting of `undef` indicated that those parameters should be use the [Optional](https://puppet.com/docs/puppet/6.21/lang_data_abstract.html#the-optional-data-type) data type while the remaining were either conformed to the [init.pp](https://github.com/cringdahl/puppet-repose/blob/puppet6/manifests/init.pp) file which has already been updated.

Special mention: filters and services

The `filters` and `services` parameters describe a filter chain which consists of a numerical ordering to a set of mapped characters.  [Hash](https://puppet.com/docs/puppet/6.21/lang_data_hash.html#lang_data_hash) was the most descriptive form that I could find, however the defaults of `undef` required them to be [Optional](https://puppet.com/docs/puppet/6.21/lang_data_abstract.html#the-optional-data-type) as well. While the existing tests showed that a nested Hash would be necessary for `filters`, `services` had no such indication so it was typed to String.

### Spec updates

Test cases referencing the `repose9` parameter were removed, the updated `raise_error` method had the error type removed as an argument, and escaped characters were no longer needed. 

The test cases which specified `without(/https-port=/)` had those snippets cut. I am unsure as to why there is a discrepancy between the value being populated and was not able to determine how it previously passed. This should be able to be added in by removing the `https_port` parameter in the test in the test case if that is preferred.

### Template updates

The `repose9` conditionals and their contents were removed. No other considerations were given to it.

## Running the Tests

The tests can be run through the pdk.

```bash
pdk test unit
```
## Additional Info:

**Story:** https://jira.rax.io/browse/CF-2789

